### PR TITLE
ADST/TOZPATRON-342/TitleValidationFix

### DIFF
--- a/Toz.Dotnet/Toz.Dotnet.Models/News.cs
+++ b/Toz.Dotnet/Toz.Dotnet.Models/News.cs
@@ -14,7 +14,8 @@ namespace Toz.Dotnet.Models
 
         [JsonProperty("title")]
         [Required(ErrorMessageResourceType = typeof(Resources.ModelsDataValidation), ErrorMessageResourceName = "EmptyField")]
-        [StringLength(100, MinimumLength = 1, ErrorMessageResourceType = typeof(Resources.ModelsDataValidation), ErrorMessageResourceName = "MaxLength")]    
+        [StringLength(100, ErrorMessageResourceType = typeof(Resources.ModelsDataValidation), ErrorMessageResourceName = "MaxLength")]
+        [RegularExpression(@"(^(?=.*[a-zA-Z])((\S)+(\s(?!$))?)+)$", ErrorMessageResourceType = typeof(Resources.ModelsDataValidation), ErrorMessageResourceName = "InvalidValue")]
         public string Title {get; set;}
 
         [JsonProperty("published")]
@@ -31,7 +32,7 @@ namespace Toz.Dotnet.Models
 
         [JsonProperty("contents")]
         [Required(ErrorMessageResourceType = typeof(Resources.ModelsDataValidation), ErrorMessageResourceName = "EmptyField")]
-        [StringLength(1000, MinimumLength = 1, ErrorMessageResourceType = typeof(Resources.ModelsDataValidation), ErrorMessageResourceName = "MaxLength")]   
+        [StringLength(1000, ErrorMessageResourceType = typeof(Resources.ModelsDataValidation), ErrorMessageResourceName = "MaxLength")]   
         public string Contents {get; set;}
 
         [JsonIgnore]

--- a/Toz.Dotnet/Toz.Dotnet/Views/News/Add.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/News/Add.cshtml
@@ -2,30 +2,31 @@
 @model Toz.Dotnet.Models.News
 @inject IViewLocalizer Localizer
 
+@{
+    ViewData["Title"] = @Localizer["PageTitle"];
+}
+
 <div class="container-fluid center">
     <form class="form-horizontal" asp-controller="News" asp-action="Add" method="POST" enctype="multipart/form-data">
         <fieldset class="pagetitle">
             <legend class="pagetitlelegend">@Localizer["PageTitle"]</legend>
             <input type="hidden" name="status" value="Released" />
-
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Title"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Title" class="form-control" id="Title">
+                    <input asp-for="Title" class="form-control" id="Title">                            
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Title)
+                    <span asp-validation-for="Title" class="help-block"></span> 
                 </div>
             </div>
-
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Text"]</label>
-                <div class="col-sm-10 textareaContainer">
-                    <textarea asp-for="Contents" class="form-control" id="Text" cols="20" rows="4" style="resize: vertical"></textarea>
+                <div class="col-sm-10">
+                    <textarea asp-for="Contents" class="form-control" id="Contents" cols="20" rows="4" style="resize: vertical"></textarea>               
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Contents)
+                    <span asp-validation-for="Contents" class="help-block"></span>
                 </div>
             </div>
-
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Photo"]</label>
                 <div class="col-sm-10 input-group">

--- a/Toz.Dotnet/Toz.Dotnet/Views/News/Edit.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/News/Edit.cshtml
@@ -12,25 +12,25 @@
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Id"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Id" class="form-control" id="Id" disabled>
+                    <input asp-for="Id" class="form-control" id="Id" disabled>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Title"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Title" class="form-control" id="Title">
+                    <input asp-for="Title" class="form-control" id="Title">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Title)
+                    <span asp-validation-for="Title" class="help-block"></span> 
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Text"]</label>
-                <div class="col-sm-10 textareaContainer">
+                <div class="col-sm-10">
                     <textarea asp-for="Contents" class="form-control" id="Text" cols="20" rows="4" style="resize: vertical"></textarea>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Contents)
+                    <span asp-validation-for="Contents" class="help-block"></span> 
                 </div>
             </div>
 

--- a/Toz.Dotnet/Toz.Dotnet/Views/News/Index.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/News/Index.cshtml
@@ -61,7 +61,7 @@
                             @if (@item.Type == NewsStatus.Unreleased)
                             {
                                 <td>
-                                    <div class="unreleased pagination-centered">
+                                    <div class="unreleased">
                                         <div class="glyphicon glyphicon-exclamation-sign"></div>
                                         @Localizer["Unreleased"]
                                     </div>
@@ -70,7 +70,7 @@
                             else if (@item.Type == NewsStatus.Archived)
                             {
                                 <td>
-                                    <div class="archived pagination-centered">
+                                    <div class="archived">
                                         <div class="glyphicon glyphicon-exclamation-sign"></div>
                                         @Localizer["Archived"]
                                     </div>

--- a/Toz.Dotnet/Toz.Dotnet/Views/Organization/Info.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/Organization/Info.cshtml
@@ -21,7 +21,7 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Name" class="form-control" id="Name">
+                            <input asp-for="Name" class="form-control" id="Name">
                             <span asp-validation-for="Name"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
@@ -39,7 +39,7 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Address.Street" class="form-control" id="Stret">
+                            <input asp-for="Address.Street" class="form-control" id="Street">
                             <span asp-validation-for="Address.Street"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
@@ -54,13 +54,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Address.HouseNumber" class="form-control" id="HouseNumber">
+                            <input asp-for="Address.HouseNumber" class="form-control" id="HouseNumber">
                             <span asp-validation-for="Address.HouseNumber"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Address.HouseNumber" class="form-control" id="HouseNumber" readonly>
+                            <input asp-for="Address.HouseNumber" class="form-control" id="HouseNumber" readonly>
                         }
                     </div>
                 </div>
@@ -69,13 +69,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Address.ApartmentNumber" class="form-control" id="ApartmentNumber">
+                            <input asp-for="Address.ApartmentNumber" class="form-control" id="ApartmentNumber">
                             <span asp-validation-for="Address.ApartmentNumber"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Address.ApartmentNumber" class="form-control" id="ApartmentNumber" readonly>
+                            <input asp-for="Address.ApartmentNumber" class="form-control" id="ApartmentNumber" readonly>
                         }
                     </div>
                 </div>
@@ -84,13 +84,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Address.PostCode" class="form-control" id="PostCode">
+                            <input asp-for="Address.PostCode" class="form-control" id="PostCode">
                             <span asp-validation-for="Address.PostCode"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Address.PostCode" class="form-control" id="PostCode" readonly>
+                            <input asp-for="Address.PostCode" class="form-control" id="PostCode" readonly>
                         }
                     </div>
                 </div>
@@ -99,13 +99,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Address.City" class="form-control" id="City">
+                            <input asp-for="Address.City" class="form-control" id="City">
                             <span asp-validation-for="Address.City"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Address.City" class="form-control" id="City" readonly>
+                            <input asp-for="Address.City" class="form-control" id="City" readonly>
                         }
                     </div>
                 </div>
@@ -114,13 +114,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Address.Country" class="form-control" id="Country">
+                            <input asp-for="Address.Country" class="form-control" id="Country">
                             <span asp-validation-for="Address.Country"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Address.Country" class="form-control" id="Country" readonly>
+                            <input asp-for="Address.Country" class="form-control" id="Country" readonly>
                         }
                     </div>
                 </div>
@@ -132,13 +132,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Contact.Email" class="form-control" id="Email">
+                            <input asp-for="Contact.Email" class="form-control" id="Email">
                             <span asp-validation-for="Contact.Email"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Contact.Email" class="form-control" id="Email" readonly>
+                            <input asp-for="Contact.Email" class="form-control" id="Email" readonly>
                         }
                     </div>
                 </div>
@@ -147,13 +147,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Contact.Phone" class="form-control" id="Phone">
+                            <input asp-for="Contact.Phone" class="form-control" id="Phone">
                             <span asp-validation-for="Contact.Phone"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Contact.Phone" class="form-control" id="Phone" readonly>
+                            <input asp-for="Contact.Phone" class="form-control" id="Phone" readonly>
                         }
                     </div>
                 </div>
@@ -162,13 +162,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Contact.Fax" class="form-control" id="Fax">
+                            <input asp-for="Contact.Fax" class="form-control" id="Fax">
                             <span asp-validation-for="Contact.Fax"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Contact.Fax" class="form-control" id="Fax" readonly>
+                            <input asp-for="Contact.Fax" class="form-control" id="Fax" readonly>
                         }
                     </div>
                 </div>
@@ -177,13 +177,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="Contact.Website" class="form-control" id="Website">
+                            <input asp-for="Contact.Website" class="form-control" id="Website">
                             <span asp-validation-for="Contact.Website"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="Contact.Website" class="form-control" id="Website" readonly>
+                            <input asp-for="Contact.Website" class="form-control" id="Website" readonly>
                         }
                     </div>
                 </div>
@@ -195,13 +195,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="BankAccount.Number" class="form-control" id="BankAccountNumber">
+                            <input asp-for="BankAccount.Number" class="form-control" id="BankAccountNumber">
                             <span asp-validation-for="BankAccount.Number"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="BankAccount.Number" class="form-control" id="BankAccountNumber" readonly>
+                            <input asp-for="BankAccount.Number" class="form-control" id="BankAccountNumber" readonly>
                         }
                     </div>
                 </div>
@@ -210,13 +210,13 @@
                     <div class="col-sm-10">
                         @if (IsEditMode)
                         {
-                            <input type="text" asp-for="BankAccount.BankName" class="form-control" id="BankName">
+                            <input asp-for="BankAccount.BankName" class="form-control" id="BankName">
                             <span asp-validation-for="BankAccount.Number"></span>
                             <span class="glyphicon form-control-feedback"></span>
                         }
                         else
                         {
-                            <input type="text" asp-for="BankAccount.BankName" class="form-control" id="BankName" readonly>
+                            <input asp-for="BankAccount.BankName" class="form-control" id="BankName" readonly>
                         }
                     </div>
                 </div>

--- a/Toz.Dotnet/Toz.Dotnet/Views/Pets/Add.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/Pets/Add.cshtml
@@ -1,5 +1,4 @@
 @using Microsoft.AspNetCore.Mvc.Localization
-@using Toz.Dotnet.Models.EnumTypes
 @model Toz.Dotnet.Models.Pet
 @inject IViewLocalizer Localizer
 
@@ -14,33 +13,33 @@
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Name"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Name" class="form-control" id="Name">
+                    <input asp-for="Name" class="form-control" id="Name">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Name)
+                    <span asp-validation-for="Name" class="help-block"></span>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Type"]</label>
-                <div class="col-sm-10 selectContainer">
+                <div class="col-sm-10">
                     <select asp-for="Type" class="form-control" id="Type">
                         <option value="0"></option>
                         <option value="1">@Localizer["Dog"]</option>
                         <option value="2">@Localizer["Cat"]</option>
                     </select>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Type)
+                    <span asp-validation-for="Type" class="help-block"></span>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Sex"]</label>
-                <div class="col-sm-10 selectContainer">
+                <div class="col-sm-10">
                     <select asp-for="Sex" class="form-control" id="Sex">
                         <option value="0"></option>
                         <option value="1">@Localizer["Male"]</option>
                         <option value="2">@Localizer["Female"]</option>
                     </select>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Sex)
+                    <span asp-validation-for="Sex"></span>
                 </div>
             </div>
             <div class="form-group row">
@@ -74,21 +73,21 @@
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Description"]</label>
-                <div class="col-sm-10 textareContainer">
+                <div class="col-sm-10">
                     <textarea asp-for="Description" class="form-control" id="Description" cols="10" rows="4" style="resize: vertical"></textarea>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Description)
+                    <span asp-validation-for="Description"></span>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Address"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Address" class="form-control" id="Address">
+                    <input asp-for="Address" class="form-control" id="Address">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Address)
+                    <span asp-validation-for="Address"></span>
                 </div>
             </div>
-            
+
             <div class="form-group row" style="text-align: center">
                 <span class="unhandled-error-span">@ViewData["UnhandledError"]</span>
             </div>

--- a/Toz.Dotnet/Toz.Dotnet/Views/Pets/Edit.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/Pets/Edit.cshtml
@@ -1,5 +1,4 @@
 @using Microsoft.AspNetCore.Mvc.Localization
-@using Toz.Dotnet.Models.EnumTypes
 @model Toz.Dotnet.Models.Pet
 @inject IViewLocalizer Localizer
 
@@ -14,39 +13,39 @@
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Id"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Id" class="form-control" id="Id" disabled>
+                    <input asp-for="Id" class="form-control" id="Id" disabled>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Name"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Name" class="form-control" id="Name">
+                    <input asp-for="Name" class="form-control" id="Name">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Name)
+                    <span asp-validation-for="Name"></span>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Type"]</label>
-                <div class="col-sm-10 selectContainer">
+                <div class="col-sm-10">
                     <select asp-for="Type" class="form-control" id="Type">
                         <option value="0"></option>
                         <option value="1">@Localizer["Dog"]</option>
                         <option value="2">@Localizer["Cat"]</option>
                     </select>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Type)
+                    <span asp-validation-for="Type"></span>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Sex"]</label>
-                <div class="col-sm-10 selectContainer">
+                <div class="col-sm-10">
                     <select asp-for="Sex" class="form-control" id="Sex">
                         <option value="0"></option>
                         <option value="1">@Localizer["Male"]</option>
                         <option value="2">@Localizer["Female"]</option>
                     </select>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Sex)
+                    <span asp-validation-for="Sex"></span>
                 </div>
             </div>
             <div class="form-group row">
@@ -80,18 +79,18 @@
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Description"]</label>
-                <div class="col-sm-10 textareaContainer">
+                <div class="col-sm-10">
                     <textarea asp-for="Description" class="form-control" id="Description" cols="10" rows="4" style="resize: vertical"></textarea>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Description)
+                    <span asp-validation-for="Description"></span>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Address"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Address" class="form-control" id="Address">
+                    <input asp-for="Address" class="form-control" id="Address">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Address)
+                    <span asp-validation-for="Address"></span>
                 </div>
             </div>
             

--- a/Toz.Dotnet/Toz.Dotnet/Views/Schedule/AddReservation.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/Schedule/AddReservation.cshtml
@@ -1,5 +1,4 @@
 @using Microsoft.AspNetCore.Mvc.Localization
-@using Toz.Dotnet.Models.EnumTypes
 @model Toz.Dotnet.Models.ViewModels.ReservationToken
 @inject IViewLocalizer Localizer
 
@@ -16,17 +15,17 @@
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["FirstName"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="FirstName" class="form-control" id="FirstName">
+                    <input asp-for="FirstName" class="form-control" id="FirstName">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.FirstName)
+                    <span asp-validation-for="FirstName"></span>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["LastName"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="LastName" class="form-control" id="LastName">
+                    <input asp-for="LastName" class="form-control" id="LastName">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.LastName)
+                    <span asp-validation-for="LastName"></span>
                 </div>
             </div>
             

--- a/Toz.Dotnet/Toz.Dotnet/Views/Users/Add.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/Users/Add.cshtml
@@ -1,5 +1,4 @@
 @using Microsoft.AspNetCore.Mvc.Localization
-@using Toz.Dotnet.Models.EnumTypes
 @model Toz.Dotnet.Models.User
 @inject IViewLocalizer Localizer
 @{
@@ -14,36 +13,36 @@
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["FirstName"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="FirstName" class="form-control" id="FirstName">
+                    <input asp-for="FirstName" class="form-control" id="FirstName">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.FirstName)
+                    <span asp-validation-for="FirstName"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["LastName"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="LastName" class="form-control" id="LastName">
+                    <input asp-for="LastName" class="form-control" id="LastName">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.LastName)
+                    <span asp-validation-for="LastName"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["PhoneNumber"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="PhoneNumber" class="form-control" id="PhoneNumber">
+                    <input asp-for="PhoneNumber" class="form-control" id="PhoneNumber">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.PhoneNumber)
+                    <span asp-validation-for="PhoneNumber"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Email"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Email" class="form-control" id="Email">
+                    <input asp-for="Email" class="form-control" id="Email">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Email)
+                    <span asp-validation-for="Email"></span>
                 </div>
             </div>
             
@@ -52,20 +51,20 @@
                 <div class="col-sm-10">
                     <input type="password" asp-for="Password" class="form-control" id="Password">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Password)
+                    <span asp-validation-for="Password"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Purpose"]</label>
-                <div class="col-sm-10 selectContainer">
+                <div class="col-sm-10">
                     <select asp-for="Roles" class="form-control" id="Roles" multiple="multiple">
                         <option value="1">@Localizer["Volunteer"]</option>
                         <option value="2">@Localizer["TozWorker"]</option>
                         <option value="3">@Localizer["Administrator"]</option>
                     </select>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Roles)
+                    <span asp-validation-for="Roles"></span>
                 </div>
             </div>
             

--- a/Toz.Dotnet/Toz.Dotnet/Views/Users/Edit.cshtml
+++ b/Toz.Dotnet/Toz.Dotnet/Views/Users/Edit.cshtml
@@ -1,5 +1,4 @@
 ﻿@using Microsoft.AspNetCore.Mvc.Localization
-@using Toz.Dotnet.Models.EnumTypes
 @model Toz.Dotnet.Models.User
 @inject IViewLocalizer Localizer
 @{
@@ -14,43 +13,43 @@
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Id"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Id" class="form-control" id="Id" disabled>
+                    <input asp-for="Id" class="form-control" id="Id" disabled>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["FirstName"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="FirstName" class="form-control" id="FirstName">
+                    <input asp-for="FirstName" class="form-control" id="FirstName">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.FirstName)
+                    <span asp-validation-for="FirstName"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["LastName"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="LastName" class="form-control" id="LastName">
+                    <input asp-for="LastName" class="form-control" id="LastName">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.LastName)
+                    <span asp-validation-for="LastName"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["PhoneNumber"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="PhoneNumber" class="form-control" id="PhoneNumber">
+                    <input asp-for="PhoneNumber" class="form-control" id="PhoneNumber">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.PhoneNumber)
+                    <span asp-validation-for="PhoneNumber"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Email"]</label>
                 <div class="col-sm-10">
-                    <input type="text" asp-for="Email" class="form-control" id="Email">
+                    <input asp-for="Email" class="form-control" id="Email">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Email)
+                    <span asp-validation-for="Email"></span>
                 </div>
             </div>
             
@@ -59,20 +58,20 @@
                 <div class="col-sm-10">
                     <input type="password" asp-for="Password" class="form-control" id="Password">
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Password)
+                    <span asp-validation-for="Password"></span>
                 </div>
             </div>
 
             <div class="form-group row">
                 <label class="col-sm-2 control-label">@Localizer["Purpose"]</label>
-                <div class="col-sm-10 selectContainer">
+                <div class="col-sm-10">
                     <select asp-for="Roles" class="form-control" id="Roles" multiple="multiple">
                         <option value="1">@Localizer["Volunteer"]</option>
                         <option value="2">@Localizer["TozWorker"]</option>
                         <option value="3">@Localizer["Administrator"]</option>
                     </select>
                     <span class="glyphicon form-control-feedback"></span>
-                    @Html.ValidationMessageFor(m => m.Roles)
+                    <span asp-validation-for="Roles"></span>
                 </div>
             </div>
             


### PR DESCRIPTION
1. Fixed the validation for News.Title. Strings containing only special characters, spaces or numbers have been disallowed.
2. Replaced "@Html.ValidationMessageFor" with ASP.Net Core recommended tag helpers ("asp-validation-for") in all views.
3. Removed type="text" from all inputs with asp-for tag helper (tag helpers add type="text" by themself, so adding the same thing into view's html is redundant)
3. Removed some unused css classes and usings from views.
4. Fixed missing red colour for validation messages inside News views.